### PR TITLE
fix: guard file reads to prevent EISDIR during install

### DIFF
--- a/src/utils/config-scanner.ts
+++ b/src/utils/config-scanner.ts
@@ -81,8 +81,10 @@ function scanCategoryDir(dir: string, category: string): ConfigFile[] {
 
     if (entry.isDirectory()) {
       // Scan subdirectory
-      const subFiles = fs.readdirSync(fullPath).filter(f => f.endsWith('.md'));
-      for (const subFile of subFiles) {
+      const subEntries = fs.readdirSync(fullPath, { withFileTypes: true });
+      for (const subEntry of subEntries) {
+        if (!subEntry.isFile() || !subEntry.name.endsWith('.md')) continue;
+        const subFile = subEntry.name;
         const subFilePath = path.join(fullPath, subFile);
         const meta = parseFileMeta(subFilePath);
         files.push({
@@ -93,7 +95,7 @@ function scanCategoryDir(dir: string, category: string): ConfigFile[] {
           category,
         });
       }
-    } else if (entry.name.endsWith('.md')) {
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
       const meta = parseFileMeta(fullPath);
       files.push({
         name: meta.name,

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -122,7 +122,13 @@ function collectMdFiles(catDir: string): string[] {
     } else if (entry.isDirectory()) {
       const skillMd = path.join(catDir, entry.name, 'SKILL.md');
       if (fs.existsSync(skillMd)) {
-        files.push(path.join(entry.name, 'SKILL.md'));
+        try {
+          if (fs.statSync(skillMd).isFile()) {
+            files.push(path.join(entry.name, 'SKILL.md'));
+          }
+        } catch {
+          // Ignore invalid entries
+        }
       }
     }
   }
@@ -160,6 +166,13 @@ export function aggregateToAgentsMd(configDir: string, selectedFiles?: Record<st
     for (const file of files) {
       const filePath = path.join(catDir, file);
       if (!fs.existsSync(filePath)) continue;
+
+      try {
+        const stat = fs.statSync(filePath);
+        if (!stat.isFile()) continue;
+      } catch {
+        continue;
+      }
 
       const raw = fs.readFileSync(filePath, 'utf8');
       const body = stripFrontmatter(raw);


### PR DESCRIPTION
## Summary
Fixes install-time crash: `EISDIR: illegal operation on a directory, read`.

Closes #8.

## Changes
- `src/utils/files.ts`
  - Guard AGENTS aggregation reads with `isFile()` check before `readFileSync`
  - Harden `collectMdFiles()` to include `SKILL.md` only when it is a real file
- `src/utils/config-scanner.ts`
  - Use `withFileTypes: true` for subdirectory scans
  - Include only entries where `isFile()` and filename ends with `.md`
  - Add explicit top-level `entry.isFile()` check

## Why
Some scan/aggregation paths could treat non-file entries as markdown files. This caused directory read attempts and `EISDIR` during install (notably Codex aggregation path).

## Validation
- `npx vitest run` ✅
- `npm run build` ✅
- Manual flow: `node bin/ai-rules.cjs install` (Codex selected) ✅
