### PR TITLE
fix: normalize scanDir path separators for Windows compatibility

### DIFF
--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -14,7 +14,7 @@ export function scanDir(dir: string, base = ''): ScanResult {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
-    const relPath = base ? path.join(base, entry.name) : entry.name;
+    const relPath = base ? [base, entry.name].join('/') : entry.name;
 
     if (entry.isDirectory()) {
       Object.assign(result, scanDir(fullPath, relPath));


### PR DESCRIPTION
## What

Fix `scanDir()` producing backslash-delimited keys on Windows (`sub\nested.md` instead of `sub/nested.md`), causing lookup mismatches in cross-platform environments.

## Type

- [ ] New rule
- [ ] Rule improvement
- [x] CLI feature / fix (`src/`)
- [ ] Documentation

## Test

```bash
$ npx vitest run
✓ tests/semantic-router.test.ts (8 tests)
✓ tests/files.test.ts (10 tests)    # was 1 failed, now all pass
✓ tests/config-scanner.test.ts (7 tests)

Test Files  3 passed (3)
     Tests  25 passed (25)
```

- `npm run build` — passed
- `npx vitest run` — 25/25 passed (previously 24/25)
- Replaces `path.join(base, entry.name)` with `[base, entry.name].join('/')` to ensure consistent forward-slash keys regardless of OS.