### PR TITLE
fix: correct clone directory name in README

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -362,7 +362,7 @@ Selected rules (3):
 ```bash
 # 기여자 빠른 시작
 git clone https://github.com/JSK9999/ai-nexus.git
-cd ai-rules && npm install && npm run build
+cd ai-nexus && npm install && npm run build
 
 # config/rules/에 룰 추가 후 테스트:
 node bin/ai-rules.cjs test "your prompt"

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ We welcome rule contributions! Contributed rules are instantly available via `ai
 ```bash
 # Quick start for contributors
 git clone https://github.com/JSK9999/ai-nexus.git
-cd ai-rules && npm install && npm run build
+cd ai-nexus && npm install && npm run build
 
 # Add your rule to config/rules/, then test:
 node bin/ai-rules.cjs test "your prompt"


### PR DESCRIPTION
## Summary

Fix incorrect directory name in contributing quick start section.

## Type

- [ ] New rule
- [ ] Rule improvement
- [ ] CLI feature / fix (`src/`)
- [x] Bug fix
- [ ] Documentation

## Changes

- `README.md`
  - `cd ai-rules` → `cd ai-nexus`
- `README.ko.md`
  - `cd ai-rules` → `cd ai-nexus`

## Why

After `git clone https://github.com/JSK9999/ai-nexus.git`, the directory name is `ai-nexus`, not `ai-rules`.

## Validation

- Documentation-only change, no code impact