### PR TITLE
fix: correct clone directory name in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ PRs are reviewed based on:
 
 ```bash
 git clone https://github.com/JSK9999/ai-nexus.git
-cd ai-rules
+cd ai-nexus
 npm install
 npm run build
 npm test


### PR DESCRIPTION
## Summary

Fix incorrect directory name in development setup section.

## Type

- [ ] New rule
- [ ] Rule improvement
- [ ] CLI feature / fix (`src/`)
- [x] Bug fix
- [ ] Documentation

## Changes

- `CONTRIBUTING.md`
  - `cd ai-rules` → `cd ai-nexus`

## Why

Same issue as PR #12. After `git clone`, the directory is `ai-nexus`, not `ai-rules`.

## Validation

- Documentation-only change, no code impact