### PR TITLE
fix: rename ai-rules to ai-nexus in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# ai-rules Semantic Router 설정
+# ai-nexus Semantic Router 설정
 # 이 파일을 .env로 복사하고 API 키를 입력하세요
 # cp .env.example .env
 


### PR DESCRIPTION
## Summary

Fix leftover old branding in `.env.example` comment.

## Type

- [ ] New rule
- [ ] Rule improvement
- [ ] CLI feature / fix (`src/`)
- [x] Bug fix
- [ ] Documentation

## Changes

- `.env.example`
  - `# ai-rules Semantic Router 설정` → `# ai-nexus Semantic Router 설정`

## Why

Last remaining instance of old `ai-rules` naming outside of actual file references (`bin/ai-rules.cjs`).

## Validation

- Documentation-only change, no code impact