### PR TITLE
fix: semantic-router stdin support and project path detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-nexus",
-  "version": "1.3.21",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-nexus",
-      "version": "1.3.21",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -15,7 +15,7 @@
         "ora": "^8.0.0"
       },
       "bin": {
-        "ai-nexus": "bin/ai-rules.cjs"
+        "ai-nexus": "bin/ai-nexus.cjs"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc && cp -r src/browse dist/",
     "dev": "tsc --watch",
-    "test": "vitest",
+    "test": "vitest run",
     "lint": "eslint src/",
     "prepare": "npm run build"
   },


### PR DESCRIPTION
## Summary

Two bugs in `semantic-router.cjs` that caused the hook to silently do nothing when installed, plus a vitest watch-mode hang in CI.

## Type

- [ ] New rule
- [ ] Rule improvement
- [x] CLI feature / fix (`src/`)
- [x] Bug fix

## Changes

- `config/hooks/semantic-router.cjs`
  - **Bug 1 (silent hook):** Claude Code calls `UserPromptSubmit` hooks by passing JSON via **stdin** (`{"prompt": "..."}`), not via `process.argv[2]`. The hook was only reading `argv[2]`, so it always got `undefined` and never ran. Fixed by adding stdin JSON parsing, with `argv[2]` kept as fallback for `ai-nexus test`.
  - **Bug 2 (wrong path):** Project installs put rules in `./.claude/rules/`, but the hook always looked at `~/.claude/rules/`. Fixed by checking for a project-local rules dir first and falling back to global.
- `package.json` — `"test": "vitest"` → `"test": "vitest run"` (vitest without `run` enters interactive watch mode and never exits)
- `package-lock.json` — sync with package.json changes

## Validation

\`\`\`bash
$ npm test
✓ tests/semantic-router.test.ts (8 tests)
✓ tests/files.test.ts (10 tests)
✓ tests/config-scanner.test.ts (7 tests)
Test Files  3 passed (3)
     Tests  25 passed (25)

$ npm run build
# success

$ echo '{"prompt":"write a commit message"}' | node config/hooks/semantic-router.cjs
# → correctly activates commit.md rules
\`\`\`