### PR TITLE
fix: support category/filename format in get command

### DIFF
--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -17,8 +17,11 @@ export async function get(filename: string, options: GetOptions): Promise<void> 
   try {
     const allFiles = await fetchRegistry();
 
-    // Find matching files
-    const matches = allFiles.filter(f => f.name === filename);
+    // Find matching files - support both "react.md" and "skills/react.md"
+    const parts = filename.split('/');
+    const matches = parts.length >= 2
+      ? allFiles.filter(f => f.category === parts[0] && f.name === parts.slice(1).join('/'))
+      : allFiles.filter(f => f.name === filename);
 
     if (matches.length === 0) {
       spinner.stop();


### PR DESCRIPTION
## Summary

`ai-nexus get skills/react.md` was failing even though `ai-nexus search react` suggested that exact filename. Now both formats work.

## Type

- [ ] New rule
- [ ] Rule improvement
- [ ] CLI feature / fix (`src/`)
- [x] Bug fix

## Changes

- `src/commands/get.ts`
  - If the input contains `/`, split into `category` + `name` and filter by both fields
  - Otherwise fall back to name-only matching (existing behavior)

## Validation

```bash
# Before fix
$ ai-nexus get skills/react.md
→ "skills/react.md" not found in registry.  ❌

# After fix
$ ai-nexus get skills/python.md
→ Downloaded skills/python.md  ✅

$ ai-nexus get python.md
→ Downloaded skills/python.md  ✅  (still works)

$ npm test
✓ 25/25 passed
```