### PR TITLE
fix: update --force no longer deletes settings.json or rules-inactive/

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -133,8 +133,16 @@ export async function update(options: UpdateOptions = {}): Promise<void> {
   }
 
   // Step 3: Compare .ai-nexus/config vs .claude/ and sync
+  // Only compare files within tracked categories — exclude settings.json,
+  // rules-inactive/ (managed by semantic router), and any other untracked files.
+  const TRACKED_CATEGORIES = ['rules', 'commands', 'skills', 'agents', 'contexts', 'hooks'];
   const sourceFiles = scanDir(configDir);
-  const installedFiles = scanDir(claudeDir);
+  const allInstalledFiles = scanDir(claudeDir);
+  const installedFiles = Object.fromEntries(
+    Object.entries(allInstalledFiles).filter(([rel]) =>
+      TRACKED_CATEGORIES.some(cat => rel.startsWith(cat + '/') || rel.startsWith(cat + '\\'))
+    )
+  ) as typeof allInstalledFiles;
   const diff = compareConfigs(sourceFiles, installedFiles);
 
   if (diff.added.length === 0 && diff.modified.length === 0 && diff.removed.length === 0) {


### PR DESCRIPTION
## Summary

`ai-nexus update --force` was silently deleting `settings.json` and all `rules-inactive/` files.

## Type

- [ ] New rule
- [ ] Rule improvement
- [ ] CLI feature / fix (`src/`)
- [x] Bug fix

## Root Cause

`compareConfigs` was scanning the entire `.claude/` directory against `.ai-nexus/config/`. Files present in `.claude/` but absent from the config source (including `settings.json` and `rules-inactive/`) appeared as "removed in source" — and `--force` would delete them.

Deleted files:
- **`settings.json`** — holds the `UserPromptSubmit` hook config; deleting it silently breaks the semantic router
- **`rules-inactive/*.md`** — managed by the semantic router; deleting resets all active/inactive routing state

## Fix

Filter installed files to only tracked categories (`rules`, `commands`, `skills`, `agents`, `contexts`, `hooks`) before diffing, so unmanaged files in `.claude/` are never considered for deletion.

## Validation

```bash
# Reproduce
ai-nexus init --quick --yes
echo '{"prompt":"write a commit message"}' | node .claude/hooks/semantic-router.cjs
# → moves 20 files to rules-inactive/

# Before fix
ai-nexus update --force
# → settings.json: DELETED ❌
# → rules-inactive/: DELETED ❌

# After fix
ai-nexus update --force
# → settings.json: intact ✅
# → rules-inactive/ (20 files): intact ✅

$ npm test
✓ 25/25 passed
```