### PR TITLE
fix: guard against missing sources field in old meta.json (v1.4.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-nexus",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Unified rule manager for Claude Code, Cursor, and Codex - write once, use everywhere, save tokens",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -25,8 +25,7 @@ export async function list(): Promise<void> {
   if (fs.existsSync(metaPath)) {
     const meta: DotrulesMeta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
     console.log(`  Scope:   ${scope}`);
-    console.log(`  Mode:    ${meta.mode}`);
-    console.log(`  Sources: ${meta.sources.map(s => s.type === 'external' ? `${s.name} (${s.url})` : s.name).join(', ')}`);
+    console.log(`  Sources: ${(meta.sources ?? []).map(s => s.type === 'external' ? `${s.name} (${s.url})` : s.name).join(', ')}`);
   }
 
   // List files by category with descriptions

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -40,7 +40,7 @@ export async function update(options: UpdateOptions = {}): Promise<void> {
   }
 
   const meta: DotrulesMeta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
-  console.log(`   Sources: ${meta.sources.map(s => s.name).join(', ')}\n`);
+  console.log(`   Sources: ${(meta.sources ?? []).map(s => s.name).join(', ')}\n`);
 
   const configDir = path.join(configPath, 'config');
   const targetDir = scope === 'global' ? os.homedir() : process.cwd();
@@ -84,7 +84,7 @@ export async function update(options: UpdateOptions = {}): Promise<void> {
   // Step 2: Update external sources and re-merge new files
   const sourcesDir = path.join(configPath, 'sources');
 
-  for (const source of meta.sources) {
+  for (const source of (meta.sources ?? [])) {
     if (source.type === 'external' && source.url) {
       const repoPath = path.join(sourcesDir, source.name);
       console.log(`   📥 Updating ${source.name}...`);


### PR DESCRIPTION
## Summary

- \`list\`: deprecated \`mode\` 표시 제거, \`sources ?? []\` 가드 추가
- \`update\`: \`sources ?? []\` 가드 추가 (sources/loop 2곳)
- 버전 1.4.2 bump

구버전으로 설치한 사용자의 \`meta.json\`에 \`sources\` 필드가 없을 경우 \`TypeError: Cannot read properties of undefined (reading 'map')\` 크래시 방지

## Test plan

- [ ] \`ai-nexus list\` with normal meta.json
- [ ] \`ai-nexus list\` with meta.json missing \`sources\` field
- [ ] \`ai-nexus update\` with meta.json missing \`sources\` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)