### PR TITLE
fix: harden security for awesome-claude-code submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,27 @@ npx ai-nexus update
 
 ---
 
+## Network & Privacy
+
+ai-nexus runs locally. Here is a complete list of network requests the tool may make:
+
+| When | Destination | Purpose | Required? |
+|------|-------------|---------|-----------|
+| Semantic routing (per prompt) | `api.openai.com` | AI-powered rule selection via GPT-4o-mini | **Opt-in only** — requires `SEMANTIC_ROUTER_ENABLED=true` + `OPENAI_API_KEY` |
+| Semantic routing (per prompt) | `api.anthropic.com` | AI-powered rule selection via Claude Haiku | **Opt-in only** — requires `SEMANTIC_ROUTER_ENABLED=true` + `ANTHROPIC_API_KEY` |
+| `search`, `get`, `browse` | `api.github.com` | Fetch community rule registry | Only when you run these commands |
+| `get` | `raw.githubusercontent.com` | Download rule file content | Only when you run `get` |
+| `browse` | `localhost:3847` | Local-only HTTP server for marketplace UI | Bound to `127.0.0.1` — not accessible from other machines |
+| `install --rules <url>` | Git remote host | Clone a team rules repository | Only when you provide a `--rules` URL |
+
+**No telemetry. No analytics. No external data collection.**
+
+- API keys are read from environment variables only — never stored on disk or logged.
+- Your prompts are sent to OpenAI/Anthropic **only** when semantic routing is explicitly enabled. Without it, keyword-based fallback runs entirely offline.
+- The `browse` server binds to `127.0.0.1` and is not accessible from the network.
+
+---
+
 ## Rule Marketplace
 
 ![browse](https://raw.githubusercontent.com/JSK9999/ai-nexus/main/docs/nexus-marketplace.png)

--- a/config/hooks/semantic-router.cjs
+++ b/config/hooks/semantic-router.cjs
@@ -9,7 +9,7 @@ const RULES_DIR = fs.existsSync(_projectRules)
   ? _projectRules
   : path.join(os.homedir(), '.claude/rules');
 const INACTIVE_DIR = RULES_DIR.replace(/rules$/, 'rules-inactive');
-const SEMANTIC_ROUTER_ENABLED = process.env.SEMANTIC_ROUTER_ENABLED !== 'false';
+const SEMANTIC_ROUTER_ENABLED = process.env.SEMANTIC_ROUTER_ENABLED === 'true';
 
 // Static keyword map (fallback for files without frontmatter)
 const STATIC_KEYWORD_MAP = {

--- a/src/commands/browse.ts
+++ b/src/commands/browse.ts
@@ -218,7 +218,7 @@ export async function browse(port = 3847): Promise<void> {
     }
   });
 
-  server.listen(port, () => {
+  server.listen(port, '127.0.0.1', () => {
     console.log(`\n  ai-nexus browse: http://localhost:${port}`);
     console.log(`  Ctrl+C to quit\n`);
     openBrowser(`http://localhost:${port}`);

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import fs from 'fs';
 
 export interface RuleSource {
@@ -47,10 +47,13 @@ export function cloneRepo(url: string, targetDir: string): void {
       stdio: 'pipe',
     });
   } else {
-    // Clone new repo
-    execSync(`git clone --depth 1 ${normalizedUrl} "${targetDir}"`, {
+    // Clone new repo (use spawnSync to avoid command injection)
+    const result = spawnSync('git', ['clone', '--depth', '1', normalizedUrl, targetDir], {
       stdio: 'pipe',
     });
+    if (result.status !== 0) {
+      throw new Error(`git clone failed: ${result.stderr?.toString() || 'unknown error'}`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Make `SEMANTIC_ROUTER_ENABLED` opt-in (`=== 'true'`) in CJS hook to align with TS source
- Add **Network & Privacy** section to README documenting all external network requests
- Fix potential command injection in `git.ts` by replacing `execSync` with `spawnSync`
- Bind `browse` server explicitly to `127.0.0.1` to prevent network exposure

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 25 tests pass
- [x] Keyword fallback routing still works without `SEMANTIC_ROUTER_ENABLED=true`
- [x] `browse` command still accessible at `localhost:3847`

🤖 Generated with [Claude Code](https://claude.com/claude-code)