### PR TITLE
fix: use relative home link on docs landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -706,7 +706,7 @@
   <header>
     <div class="container">
       <nav>
-        <a href="/" class="logo"><img src="logo.svg" alt="" style="width:28px;height:28px;vertical-align:middle;margin-right:8px;border-radius:6px">ai-nexus</a>
+        <a href="./" class="logo"><img src="logo.svg" alt="" style="width:28px;height:28px;vertical-align:middle;margin-right:8px;border-radius:6px">ai-nexus</a>
         <div class="nav-links">
           <a href="https://github.com/JSK9999/ai-nexus">GitHub</a>
           <a href="docs.html">Docs</a>


### PR DESCRIPTION
## Summary
- Fix docs homepage header logo link in `docs/index.html` from `href="/"` to `href="./"`
- Keep navigation within the GitHub Pages project path (`/<repo>/`) instead of jumping to domain root
- Align behavior with relative-path navigation used in localized docs pages

## Test plan
- [x] Verify `docs/index.html` logo link is relative (`./`)
- [x] Open project-site style URL (`.../ai-nexus/`) and click logo/home in header
- [x] Confirm navigation stays in repo site root and does not jump to `/`

Closes #27
