### PR TITLE
docs: add semantic router setup guide

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -114,6 +114,8 @@ export SEMANTIC_ROUTER_ENABLED=true
 
 GPT-4o-mini 또는 Claude Haiku가 프롬프트를 분석해 적절한 룰을 선택합니다. 비용: 월 ~$0.50. 명시적으로 활성화해야 동작합니다.
 
+> **상세 설정 가이드:** [시맨틱 라우터 설정](https://jsk9999.github.io/ai-nexus/docs.html#semantic-router-setup) — 프로바이더 선택, 환경 변수, 커스텀 모델, 동작 확인 방법.
+
 **AI 없이** (기본값):
 프롬프트의 키워드를 매칭해서 룰을 활성화합니다. 비용 없음, API 키 불필요.
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ export SEMANTIC_ROUTER_ENABLED=true
 
 GPT-4o-mini or Claude Haiku analyzes your prompt and picks the right rules. Cost: ~$0.50/month. Requires explicit opt-in.
 
+> **Full setup guide:** [Semantic Router Setup](https://jsk9999.github.io/ai-nexus/docs.html#semantic-router-setup) — provider selection, environment variables, custom models, and verification.
+
 **Without AI** (default):
 Keyword matching activates rules based on words in your prompt. Zero cost, no API key needed.
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -138,6 +138,7 @@
       <a href="#update-local-priority">Update & Local Priority</a>
       <a href="#rule-format">Rule Format</a>
       <div class="group">Advanced</div>
+      <a href="#semantic-router-setup">Semantic Router Setup</a>
       <a href="#team-rules">Team Rules</a>
       <a href="#multi-source">Multi-Source</a>
       <a href="#community">Community Registry</a>
@@ -340,6 +341,54 @@ Your rule content...</code></pre>
           <tr><td><code>contexts/</code></td><td>Context files (@dev, @research)</td></tr>
         </tbody>
       </table>
+
+      <!-- Semantic Router Setup -->
+      <h2 id="semantic-router-setup">Semantic Router Setup</h2>
+      <p>By default, ai-nexus uses <strong>keyword matching</strong> to select rules — no API key needed, zero cost. For smarter rule selection, enable AI-powered routing.</p>
+
+      <h3>Step 1: Choose a Provider</h3>
+      <table>
+        <thead><tr><th>Provider</th><th>Model</th><th>Cost</th></tr></thead>
+        <tbody>
+          <tr><td>OpenAI</td><td>gpt-4o-mini (default)</td><td>~$0.50/month</td></tr>
+          <tr><td>Anthropic</td><td>claude-3-haiku (default)</td><td>~$0.50/month</td></tr>
+        </tbody>
+      </table>
+      <p>Only one provider is needed. If both keys are set, Anthropic is used first.</p>
+
+      <h3>Step 2: Set Environment Variables</h3>
+      <p>Add the following to your shell profile (<code>~/.zshrc</code>, <code>~/.bashrc</code>, or <code>~/.bash_profile</code>):</p>
+      <pre><code><span class="cm"># Option A: OpenAI</span>
+<span class="kw">export</span> OPENAI_API_KEY=sk-xxx
+<span class="kw">export</span> SEMANTIC_ROUTER_ENABLED=true
+
+<span class="cm"># Option B: Anthropic</span>
+<span class="kw">export</span> ANTHROPIC_API_KEY=sk-ant-xxx
+<span class="kw">export</span> SEMANTIC_ROUTER_ENABLED=true</code></pre>
+      <p>Then reload your shell:</p>
+      <pre><code><span class="cm">$</span> <span class="hl">source ~/.zshrc</span></code></pre>
+
+      <h3>Step 3: Custom Model (Optional)</h3>
+      <p>Override the default model with these environment variables:</p>
+      <pre><code><span class="cm"># Use a different OpenAI model</span>
+<span class="kw">export</span> OPENAI_MODEL=gpt-4o
+
+<span class="cm"># Use a different Anthropic model</span>
+<span class="kw">export</span> ANTHROPIC_MODEL=claude-3-5-haiku-20241022</code></pre>
+
+      <h3>Step 4: Verify</h3>
+      <p>Test that the semantic router is working:</p>
+      <pre><code><span class="cm">$</span> <span class="hl">npx ai-nexus test "write a react component"</span>
+
+Selected rules (semantic):
+  • rules/essential.md
+  • skills/react.md
+  • rules/typescript.md</code></pre>
+      <p>If the output shows <code>(semantic)</code>, AI routing is active. If it shows <code>(keyword)</code>, check that your API key and <code>SEMANTIC_ROUTER_ENABLED</code> are set correctly.</p>
+
+      <div class="callout">
+        <strong>Security note:</strong> API keys are read from environment variables only — never stored on disk or logged by ai-nexus.
+      </div>
 
       <!-- Team Rules -->
       <h2 id="team-rules">Team Rules</h2>

--- a/docs/ko/docs.html
+++ b/docs/ko/docs.html
@@ -138,6 +138,7 @@
       <a href="#update-local-priority">업데이트 & 로컬 우선</a>
       <a href="#rule-format">규칙 형식</a>
       <div class="group">고급</div>
+      <a href="#semantic-router-setup">시맨틱 라우터 설정</a>
       <a href="#team-rules">팀 규칙</a>
       <a href="#multi-source">멀티 소스</a>
       <a href="#community">커뮤니티 레지스트리</a>
@@ -340,6 +341,54 @@ Selected rules (3):
           <tr><td><code>contexts/</code></td><td>컨텍스트 파일 (@dev, @research)</td></tr>
         </tbody>
       </table>
+
+      <!-- 시맨틱 라우터 설정 -->
+      <h2 id="semantic-router-setup">시맨틱 라우터 설정</h2>
+      <p>기본적으로 ai-nexus는 <strong>키워드 매칭</strong>으로 규칙을 선택합니다 — API 키 불필요, 비용 없음. 더 정확한 규칙 선택을 원하면 AI 라우팅을 활성화하세요.</p>
+
+      <h3>1단계: 프로바이더 선택</h3>
+      <table>
+        <thead><tr><th>프로바이더</th><th>모델</th><th>비용</th></tr></thead>
+        <tbody>
+          <tr><td>OpenAI</td><td>gpt-4o-mini (기본값)</td><td>월 ~$0.50</td></tr>
+          <tr><td>Anthropic</td><td>claude-3-haiku (기본값)</td><td>월 ~$0.50</td></tr>
+        </tbody>
+      </table>
+      <p>하나의 프로바이더만 있으면 됩니다. 두 키 모두 설정된 경우 Anthropic이 우선 사용됩니다.</p>
+
+      <h3>2단계: 환경 변수 설정</h3>
+      <p>셸 프로필 (<code>~/.zshrc</code>, <code>~/.bashrc</code>, 또는 <code>~/.bash_profile</code>)에 다음을 추가하세요:</p>
+      <pre><code><span class="cm"># 방법 A: OpenAI</span>
+<span class="kw">export</span> OPENAI_API_KEY=sk-xxx
+<span class="kw">export</span> SEMANTIC_ROUTER_ENABLED=true
+
+<span class="cm"># 방법 B: Anthropic</span>
+<span class="kw">export</span> ANTHROPIC_API_KEY=sk-ant-xxx
+<span class="kw">export</span> SEMANTIC_ROUTER_ENABLED=true</code></pre>
+      <p>셸을 다시 로드하세요:</p>
+      <pre><code><span class="cm">$</span> <span class="hl">source ~/.zshrc</span></code></pre>
+
+      <h3>3단계: 커스텀 모델 (선택사항)</h3>
+      <p>기본 모델 대신 다른 모델을 사용하려면 환경 변수로 지정하세요:</p>
+      <pre><code><span class="cm"># 다른 OpenAI 모델 사용</span>
+<span class="kw">export</span> OPENAI_MODEL=gpt-4o
+
+<span class="cm"># 다른 Anthropic 모델 사용</span>
+<span class="kw">export</span> ANTHROPIC_MODEL=claude-3-5-haiku-20241022</code></pre>
+
+      <h3>4단계: 확인</h3>
+      <p>시맨틱 라우터가 정상 작동하는지 테스트하세요:</p>
+      <pre><code><span class="cm">$</span> <span class="hl">npx ai-nexus test "write a react component"</span>
+
+Selected rules (semantic):
+  • rules/essential.md
+  • skills/react.md
+  • rules/typescript.md</code></pre>
+      <p>출력에 <code>(semantic)</code>이 표시되면 AI 라우팅이 활성화된 것입니다. <code>(keyword)</code>가 표시되면 API 키와 <code>SEMANTIC_ROUTER_ENABLED</code> 설정을 확인하세요.</p>
+
+      <div class="callout">
+        <strong>보안 참고:</strong> API 키는 환경 변수에서만 읽히며, ai-nexus가 디스크에 저장하거나 로그에 기록하지 않습니다.
+      </div>
 
       <!-- 팀 규칙 -->
       <h2 id="team-rules">팀 규칙</h2>


### PR DESCRIPTION
## Summary
- Add Semantic Router Setup section to docs (EN/KO) with step-by-step instructions
- Cover provider selection, environment variables, custom model override, verification
- Link from both READMEs to the docs guide