### PR TITLE
chore: bump version to 1.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-nexus",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-nexus",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-nexus",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Claude Code loads all rules every session - ai-nexus loads only what you need, syncing rules across Claude, Cursor, and Codex",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Add semantic router setup guide to docs