### PR TITLE
docs: add ETH Zurich study, privacy info, and missing commands

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -256,7 +256,7 @@ Selected rules (3):
       <h2 id="how-it-works">How It Works</h2>
 
       <h3>Claude Code: Semantic Router</h3>
-      <p>A hook runs on every prompt, analyzing what rules you actually need:</p>
+      <p>A <a href="https://arxiv.org/pdf/2602.11988" style="color:var(--accent)">study from ETH Zurich</a> (138 repos, 5,694 PRs) found that loading all rules at once hurts performance by ~3% and increases cost by 20%+. The Semantic Router solves this — a hook runs on every prompt, analyzing what rules you actually need:</p>
       <ul>
         <li><strong>With AI routing</strong> (recommended) &mdash; GPT-4o-mini or Claude Haiku analyzes your prompt and picks the right rules. Cost: ~$0.50/month.</li>
         <li><strong>Without AI</strong> (fallback) &mdash; keyword matching activates rules based on words in your prompt.</li>
@@ -389,7 +389,7 @@ Selected files (3):
       <p>If the output shows <code>AI (Semantic Router)</code>, AI routing is active. If it shows <code>Keyword matching</code>, check that your API key and <code>SEMANTIC_ROUTER_ENABLED</code> are set correctly.</p>
 
       <div class="callout">
-        <strong>Security note:</strong> API keys are read from environment variables only — never stored on disk or logged by ai-nexus.
+        <strong>Privacy &amp; Security:</strong> No telemetry. No analytics. No external data collection. API keys are read from environment variables only — never stored on disk or logged. Your prompts are sent to OpenAI/Anthropic <strong>only</strong> when semantic routing is explicitly enabled. Without it, keyword-based fallback runs entirely offline.
       </div>
 
       <!-- Team Rules -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -766,6 +766,7 @@
       <div class="container">
         <h2 class="section-title fade-in">Why ai-nexus?</h2>
         <p class="section-subtitle fade-in">Hundreds of rules installed, only 2-3 loaded. One source of truth for every tool.</p>
+        <p class="section-subtitle fade-in" style="margin-top:-40px;font-size:0.85rem;color:var(--text-tertiary)">A <a href="https://arxiv.org/pdf/2602.11988" style="color:var(--accent);text-decoration:none">study from ETH Zurich</a> (138 repos, 5,694 PRs) confirms: loading all rules at once hurts performance by ~3% and increases cost by 20%+.</p>
         <div class="comparison">
           <div class="comparison-card before fade-in">
             <h3>Before</h3>
@@ -901,6 +902,26 @@ Deploy everywhere:
             <code>ai-nexus test &lt;prompt&gt;</code>
             <span>Preview which rules would load</span>
           </div>
+          <div class="command-item fade-in fade-in-delay-4">
+            <code>ai-nexus list</code>
+            <span>Show installed rules</span>
+          </div>
+          <div class="command-item fade-in fade-in-delay-5">
+            <code>ai-nexus get &lt;filename&gt;</code>
+            <span>Download a rule from community registry</span>
+          </div>
+          <div class="command-item fade-in fade-in-delay-5">
+            <code>ai-nexus add &lt;url&gt;</code>
+            <span>Add rules from a Git repository</span>
+          </div>
+          <div class="command-item fade-in fade-in-delay-5">
+            <code>ai-nexus remove &lt;name&gt;</code>
+            <span>Remove a rule source</span>
+          </div>
+          <div class="command-item fade-in fade-in-delay-5">
+            <code>ai-nexus uninstall</code>
+            <span>Remove ai-nexus installation</span>
+          </div>
         </div>
       </div>
     </section>
@@ -947,6 +968,7 @@ Deploy everywhere:
 
   <footer>
     <div class="container">
+      <p style="margin-bottom:8px;color:var(--text-secondary);font-size:0.8rem">No telemetry. No analytics. No external data collection. AI routing is opt-in only.</p>
       <p>
         Apache 2.0 License &middot;
         <a href="https://github.com/JSK9999/ai-nexus">GitHub</a> &middot;

--- a/docs/ko/docs.html
+++ b/docs/ko/docs.html
@@ -256,7 +256,7 @@ Selected rules (3):
       <h2 id="how-it-works">동작 원리</h2>
 
       <h3>Claude Code: 시맨틱 라우터</h3>
-      <p>매 프롬프트마다 훅이 실행되어 실제로 필요한 규칙을 분석합니다:</p>
+      <p><a href="https://arxiv.org/pdf/2602.11988" style="color:var(--accent)">ETH Zurich 연구</a> (138개 레포, 5,694개 PR)에 따르면 모든 규칙을 한 번에 로딩하면 성능이 ~3% 저하되고 비용이 20% 이상 증가합니다. 시맨틱 라우터가 이를 해결합니다 — 매 프롬프트마다 훅이 실행되어 실제로 필요한 규칙을 분석합니다:</p>
       <ul>
         <li><strong>AI 라우팅 사용</strong> (권장) &mdash; GPT-4o-mini 또는 Claude Haiku가 프롬프트를 분석하고 적절한 규칙을 선택. 비용: 월 ~$0.50.</li>
         <li><strong>AI 미사용</strong> (폴백) &mdash; 키워드 매칭으로 프롬프트의 단어를 기반으로 규칙 활성화.</li>
@@ -389,7 +389,7 @@ Selected files (3):
       <p>출력에 <code>AI (Semantic Router)</code>가 표시되면 AI 라우팅이 활성화된 것입니다. <code>Keyword matching</code>이 표시되면 API 키와 <code>SEMANTIC_ROUTER_ENABLED</code> 설정을 확인하세요.</p>
 
       <div class="callout">
-        <strong>보안 참고:</strong> API 키는 환경 변수에서만 읽히며, ai-nexus가 디스크에 저장하거나 로그에 기록하지 않습니다.
+        <strong>프라이버시 &amp; 보안:</strong> 텔레메트리 없음. 분석 없음. 외부 데이터 수집 없음. API 키는 환경 변수에서만 읽히며, 디스크에 저장하거나 로그에 기록하지 않습니다. 프롬프트는 시맨틱 라우팅을 명시적으로 활성화한 경우에<strong>만</strong> OpenAI/Anthropic에 전송됩니다. 미사용 시 키워드 기반 폴백이 완전히 오프라인으로 동작합니다.
       </div>
 
       <!-- 팀 규칙 -->

--- a/docs/ko/index.html
+++ b/docs/ko/index.html
@@ -766,6 +766,7 @@
       <div class="container">
         <h2 class="section-title fade-in">왜 ai-nexus인가?</h2>
         <p class="section-subtitle fade-in">수백 개 설치, 2-3개만 로딩. 모든 도구를 위한 하나의 소스.</p>
+        <p class="section-subtitle fade-in" style="margin-top:-40px;font-size:0.85rem;color:var(--text-tertiary)"><a href="https://arxiv.org/pdf/2602.11988" style="color:var(--accent);text-decoration:none">ETH Zurich 연구</a> (138개 레포, 5,694개 PR) 결과: 모든 규칙을 한 번에 로딩하면 성능이 ~3% 저하되고 비용이 20% 이상 증가합니다.</p>
         <div class="comparison">
           <div class="comparison-card before fade-in">
             <h3>Before</h3>
@@ -901,6 +902,26 @@
             <code>ai-nexus test &lt;prompt&gt;</code>
             <span>어떤 규칙이 로딩될지 미리보기</span>
           </div>
+          <div class="command-item fade-in fade-in-delay-4">
+            <code>ai-nexus list</code>
+            <span>설치된 규칙 목록 표시</span>
+          </div>
+          <div class="command-item fade-in fade-in-delay-5">
+            <code>ai-nexus get &lt;filename&gt;</code>
+            <span>커뮤니티 레지스트리에서 규칙 다운로드</span>
+          </div>
+          <div class="command-item fade-in fade-in-delay-5">
+            <code>ai-nexus add &lt;url&gt;</code>
+            <span>Git 저장소에서 규칙 추가</span>
+          </div>
+          <div class="command-item fade-in fade-in-delay-5">
+            <code>ai-nexus remove &lt;name&gt;</code>
+            <span>규칙 소스 제거</span>
+          </div>
+          <div class="command-item fade-in fade-in-delay-5">
+            <code>ai-nexus uninstall</code>
+            <span>ai-nexus 설치 제거</span>
+          </div>
         </div>
       </div>
     </section>
@@ -947,6 +968,7 @@
 
   <footer>
     <div class="container">
+      <p style="margin-bottom:8px;color:var(--text-secondary);font-size:0.8rem">텔레메트리 없음. 분석 없음. 외부 데이터 수집 없음. AI 라우팅은 옵트인 전용.</p>
       <p>
         Apache 2.0 License &middot;
         <a href="https://github.com/JSK9999/ai-nexus">GitHub</a> &middot;


### PR DESCRIPTION
## Summary
- Add ETH Zurich study reference to landing page and docs "How It Works" section (EN/KO)
- Add "No telemetry" privacy note to footer on landing pages (EN/KO)
- Strengthen privacy callout in docs pages (EN/KO)
- Add 5 missing commands (`list`, `get`, `add`, `remove`, `uninstall`) to landing page command list (EN/KO)

## Why
- ETH Zurich study is the strongest selling point but was only in README, not on the static pages
- Privacy/no-telemetry info was missing from landing page and weak in docs
- Landing page only listed 8 of 13 commands

## Files changed
- `docs/index.html` — ETH Zurich study, missing commands, privacy footer
- `docs/ko/index.html` — same (Korean)
- `docs/docs.html` — ETH Zurich study in "How It Works", privacy callout
- `docs/ko/docs.html` — same (Korean)

## Validation
- Verified all 4 files render correctly
- No breaking changes to existing content

🤖 Generated with [Claude Code](https://claude.com/claude-code)